### PR TITLE
Return ellipsoid coefficients

### DIFF
--- a/ellipsoid_fit.py
+++ b/ellipsoid_fit.py
@@ -145,5 +145,5 @@ def ellipsoid_fit(X):
     radii = np.sqrt(1. / np.abs(evals))
     radii *= np.sign(evals)
 
-    return center, evecs, radii
+    return center, evecs, radii, v
 

--- a/get_calibration_ellipsoid.py
+++ b/get_calibration_ellipsoid.py
@@ -7,7 +7,7 @@ if __name__ == '__main__':
     data = np.loadtxt("mag_out.txt")
     # data2 = data_regularize(data)
 
-    center, evecs, radii = ellipsoid_fit(data)
+    center, evecs, radii, v = ellipsoid_fit(data)
 
     a, b, c = radii
     r = (a * b * c) ** (1. / 3.)
@@ -20,6 +20,8 @@ if __name__ == '__main__':
     print('evecs: ', evecs)
     print('transformation:')
     print(transformation)
+    print('Coefficients:')
+    print(v)
     
     np.savetxt('magcal_ellipsoid.txt', np.vstack((center.T, transformation)))
 


### PR DESCRIPTION
Hello!

I have added the ellipsoid expression coefficients as a return argument from the `get_ellipsoid_fit` function.

I know this change is breaking the API, but I have found need for it and it is also closer to the original MATLAB version: https://www.mathworks.com/matlabcentral/fileexchange/24693-ellipsoid-fit

Have a nice day!